### PR TITLE
mktemp template Ubuntu compatibility patch

### DIFF
--- a/privoxy-adblock.sh
+++ b/privoxy-adblock.sh
@@ -148,7 +148,7 @@ function usage() {
 function main() {
   pidfile="$(pidfilename)"
 
-  tempfile="$(mktemp -t j)"
+  tempfile="$(mktemp -t j.XXX)"
   tempdir="$(dirname $tempfile)"
   rm ${tempfile}
 


### PR DESCRIPTION
Fixed mktemp template to be compatible with Ubuntu-based systems, and possibly more.
